### PR TITLE
Fix `anchor-is-valid` lint warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'jsx-a11y/anchor-is-valid': 'off', // Doesn’t play well with Next.js <Link> usage
+  },
+}


### PR DESCRIPTION
Fixes the lint warning seen [here](https://github.com/tailwindlabs/tailwindui-react/pull/11/files#diff-7b85da9ab10cbd05f7ff21dd633b15f1R92), appearing as a result of the way the Next.js `Link` component works.